### PR TITLE
Add prefix validation for renaming

### DIFF
--- a/sorter_v2/gui.py
+++ b/sorter_v2/gui.py
@@ -423,11 +423,18 @@ class SorterGUI(ctk.CTk):
         if not self.source_dir.get():
             messagebox.showerror("Error", "Please select a source directory")
             return False
-        
+
         if not os.path.exists(self.source_dir.get()):
             messagebox.showerror("Error", "Source directory does not exist")
             return False
-        
+
+        if self.rename_files_var.get() and not self.user_prefix.get().strip():
+            messagebox.showerror(
+                "Error",
+                "Filename prefix is required when renaming files. Using default prefix 'image'."
+            )
+            self.user_prefix.set("image")
+
         return True
     
     def get_output_directory(self, default_name):

--- a/sorter_v2/gui_standard.py
+++ b/sorter_v2/gui_standard.py
@@ -592,11 +592,16 @@ class SorterGUI:
         if not self.source_dir.get():
             messagebox.showerror("Error", "Please select a source directory")
             return False
-        
+
         if not os.path.exists(self.source_dir.get()):
             messagebox.showerror("Error", "Source directory does not exist")
             return False
-        
+
+        if self.rename_files_var.get() and not self.user_prefix.get().strip():
+            messagebox.showerror("Error",
+                                 "Filename prefix is required when renaming files. Using default prefix 'image'.")
+            self.user_prefix.set("image")
+
         return True
     
     def get_output_directory(self, default_name):


### PR DESCRIPTION
## Summary
- ensure renaming requires non-empty prefix in GUI

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68803891f69483258321f737a9cb2483